### PR TITLE
Use CoreDNS for vSphere provider

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -84,9 +84,10 @@ type CreateClusterOptions struct {
 	Egress string
 
 	// vSphere options
-	VSphereServer       string
-	VSphereDatacenter   string
-	VSphereResourcePool string
+	VSphereServer        string
+	VSphereDatacenter    string
+	VSphereResourcePool  string
+	VSphereCoreDNSServer string
 }
 
 func (o *CreateClusterOptions) InitDefaults() {
@@ -190,6 +191,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.VSphereServer, "vsphere-server", options.VSphereServer, "vsphere-server is required for vSphere. Set vCenter URL Ex: 10.192.10.30 or myvcenter.io (without https://)")
 	cmd.Flags().StringVar(&options.VSphereDatacenter, "vsphere-datacenter", options.VSphereDatacenter, "vsphere-datacenter is required for vSphere. Set the name of the datacenter in which to deploy Kubernetes VMs.")
 	cmd.Flags().StringVar(&options.VSphereResourcePool, "vsphere-resource-pool", options.VSphereDatacenter, "vsphere-resource-pool is required for vSphere. Set a valid Cluster, Host or Resource Pool in which to deploy Kubernetes VMs.")
+	cmd.Flags().StringVar(&options.VSphereCoreDNSServer, "vsphere-coredns-server", options.VSphereCoreDNSServer, "vsphere-coredns-server is required for vSphere.")
 	return cmd
 }
 
@@ -501,6 +503,11 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 				return fmt.Errorf("vsphere-resource-pool is required for vSphere. Set a valid Cluster, Host or Resource Pool in which to deploy Kubernetes VMs.")
 			}
 			cluster.Spec.CloudConfig.VSphereResourcePool = fi.String(c.VSphereResourcePool)
+
+			if c.VSphereCoreDNSServer == "" {
+				return fmt.Errorf("A coredns server is required for vSphere.")
+			}
+			cluster.Spec.CloudConfig.VSphereCoreDNSServer = fi.String(c.VSphereCoreDNSServer)
 		}
 	}
 

--- a/docs/development/vsphere-dev.md
+++ b/docs/development/vsphere-dev.md
@@ -8,6 +8,53 @@ We are using [#sig-onprem channel](https://kubernetes.slack.com/messages/sig-onp
 ## Process
 Here is a [list of requirements and tasks](https://docs.google.com/document/d/10L7I98GuW7o7QuX_1QTouxC0t0aEO_68uHKNc7o4fXY/edit#heading=h.6wyer21z75n9 "Kops-vSphere specification") that we are working on. Once the basic infrastructure for vSphere is ready, we will move these tasks to issues.
 
+## CoreDNS
+Before the support of CoreDNS is stable, use env parameter "VSPHERE_DNS=coredns" to enable using CoreDNS. Or else AWS Route53 will be the default DNS service. To use Route53, follow instructions on: https://github.com/vmware/kops/blob/vsphere-develop/docs/aws.md
+
+For now we hardcoded DNS zone to skydns.local. So your cluster name should have suffix skydns.local.
+
+### Setup CoreDNS server
+1. Login to vSphere Client.
+2. Right-Click on ESX host on which you want to deploy the DNS server.
+3. Select Deploy OVF template.
+4. Copy and paste URL for [OVA](https://storage.googleapis.com/kubernetes-anywhere-for-vsphere-cna-storage/coredns.ova).
+5. Follow next steps according to instructions mentioned in wizard.
+6. Power on the imported VM.
+7. SSH into the VM and execute ./start-dns.sh under /root
+
+### Check DNS server is ready
+On your local machine, execute the following command:
+```bash
+dig @[DNS server's IP] -p 53 NS skydns.local
+```
+
+Successful answer should look like the following:
+```bash
+; <<>> DiG 9.8.3-P1 <<>> @10.162.17.161 -p 53 NS skydns.local
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 42011
+;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
+
+;; QUESTION SECTION:
+;skydns.local.			IN	NS
+
+;; ANSWER SECTION:
+skydns.local.		160	IN	NS	ns1.ns.dns.skydns.local.
+
+;; ADDITIONAL SECTION:
+ns1.ns.dns.skydns.local. 160	IN	A	192.168.0.1
+
+;; Query time: 74 msec
+;; SERVER: 10.162.17.161#53(10.162.17.161)
+;; WHEN: Tue Mar 14 22:40:06 2017
+;; MSG SIZE  rcvd: 71
+```
+
+### Add DNS server information when create cluster
+Add ```--dns=private --vsphere-coredns-server=http://[DNS server's IP]:2379``` into the ```kops create cluster``` command line.
+
 ## Hacks
 
 ### Nodeup and protokube testing

--- a/docs/development/vsphere-dev.md
+++ b/docs/development/vsphere-dev.md
@@ -8,10 +8,11 @@ We are using [#sig-onprem channel](https://kubernetes.slack.com/messages/sig-onp
 ## Process
 Here is a [list of requirements and tasks](https://docs.google.com/document/d/10L7I98GuW7o7QuX_1QTouxC0t0aEO_68uHKNc7o4fXY/edit#heading=h.6wyer21z75n9 "Kops-vSphere specification") that we are working on. Once the basic infrastructure for vSphere is ready, we will move these tasks to issues.
 
-## CoreDNS
-Before the support of CoreDNS is stable, use env parameter "VSPHERE_DNS=coredns" to enable using CoreDNS. Or else AWS Route53 will be the default DNS service. To use Route53, follow instructions on: https://github.com/vmware/kops/blob/vsphere-develop/docs/aws.md
+## Setting up DNS
+Since vSphere doesn't have built-in DNS service, we use CoreDNS to support the DNS requirement in vSphere provider. This requires the users to setup a CoreDNS server before creating a kubernetes cluster. Please follow the following instructions to setup.
+Before the support of CoreDNS becomes stable, use env parameter "VSPHERE_DNS=coredns" to enable using CoreDNS. Or else AWS Route53 will be the default DNS service. To use Route53, follow instructions on: https://github.com/vmware/kops/blob/vsphere-develop/docs/aws.md
 
-For now we hardcoded DNS zone to skydns.local. So your cluster name should have suffix skydns.local.
+For now we hardcoded DNS zone to skydns.local. So your cluster name should have suffix skydns.local, for example: "mycluster.skydns.local"
 
 ### Setup CoreDNS server
 1. Login to vSphere Client.
@@ -20,7 +21,7 @@ For now we hardcoded DNS zone to skydns.local. So your cluster name should have 
 4. Copy and paste URL for [OVA](https://storage.googleapis.com/kubernetes-anywhere-for-vsphere-cna-storage/coredns.ova).
 5. Follow next steps according to instructions mentioned in wizard.
 6. Power on the imported VM.
-7. SSH into the VM and execute ./start-dns.sh under /root
+7. SSH into the VM and execute ./start-dns.sh under /root. Username/Password: root/kubernetes
 
 ### Check DNS server is ready
 On your local machine, execute the following command:

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -655,7 +655,8 @@ type CloudConfiguration struct {
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 
 	// vSphere cloud-config specs
-	VSphereServer       *string `json:"vSphereServer,omitempty"`
-	VSphereDatacenter   *string `json:"vSphereDatacenter,omitempty"`
-	VSphereResourcePool *string `json:"vSphereResourcePool,omitempty"`
+	VSphereServer        *string `json:"vSphereServer,omitempty"`
+	VSphereDatacenter    *string `json:"vSphereDatacenter,omitempty"`
+	VSphereResourcePool  *string `json:"vSphereResourcePool,omitempty"`
+	VSphereCoreDNSServer *string `json:"vSphereCoreDNSServer,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -651,7 +651,8 @@ type CloudConfiguration struct {
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 
 	// vSphere cloud-config specs
-	VSphereServer       *string `json:"vSphereServer,omitempty"`
-	VSphereDatacenter   *string `json:"vSphereDatacenter,omitempty"`
-	VSphereResourcePool *string `json:"vSphereResourcePool,omitempty"`
+	VSphereServer        *string `json:"vSphereServer,omitempty"`
+	VSphereDatacenter    *string `json:"vSphereDatacenter,omitempty"`
+	VSphereResourcePool  *string `json:"vSphereResourcePool,omitempty"`
+	VSphereCoreDNSServer *string `json:"vSphereCoreDNSServer,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -229,6 +229,7 @@ func autoConvert_v1alpha1_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.VSphereServer = in.VSphereServer
 	out.VSphereDatacenter = in.VSphereDatacenter
 	out.VSphereResourcePool = in.VSphereResourcePool
+	out.VSphereCoreDNSServer = in.VSphereCoreDNSServer
 	return nil
 }
 
@@ -243,6 +244,7 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha1_CloudConfiguration(in *kops
 	out.VSphereServer = in.VSphereServer
 	out.VSphereDatacenter = in.VSphereDatacenter
 	out.VSphereResourcePool = in.VSphereResourcePool
+	out.VSphereCoreDNSServer = in.VSphereCoreDNSServer
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -277,7 +277,8 @@ type CloudConfiguration struct {
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 
 	// vSphere cloud-config specs
-	VSphereServer       *string `json:"vSphereServer,omitempty"`
-	VSphereDatacenter   *string `json:"vSphereDatacenter,omitempty"`
-	VSphereResourcePool *string `json:"vSphereResourcePool,omitempty"`
+	VSphereServer        *string `json:"vSphereServer,omitempty"`
+	VSphereDatacenter    *string `json:"vSphereDatacenter,omitempty"`
+	VSphereResourcePool  *string `json:"vSphereResourcePool,omitempty"`
+	VSphereCoreDNSServer *string `json:"vSphereCoreDNSServer,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -255,6 +255,7 @@ func autoConvert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.VSphereServer = in.VSphereServer
 	out.VSphereDatacenter = in.VSphereDatacenter
 	out.VSphereResourcePool = in.VSphereResourcePool
+	out.VSphereCoreDNSServer = in.VSphereCoreDNSServer
 	return nil
 }
 
@@ -269,6 +270,7 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha2_CloudConfiguration(in *kops
 	out.VSphereServer = in.VSphereServer
 	out.VSphereDatacenter = in.VSphereDatacenter
 	out.VSphereResourcePool = in.VSphereResourcePool
+	out.VSphereCoreDNSServer = in.VSphereCoreDNSServer
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -153,7 +153,7 @@ func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 	recordsMap := make(map[string]dnsprovider.ResourceRecordSet)
 	// vSphere provider uses CoreDNS, which doesn't have rrs.List() function supported.
 	// Thus we use rrs.Get() to check every dnsHostname instead
-	if cloud.ProviderID() != "vsphere" {
+	if cloud.ProviderID() != fi.CloudProviderVSphere {
 		// TODO: We should change the filter to be a suffix match instead
 		//records, err := rrs.List("", "")
 		records, err := rrs.List()
@@ -175,7 +175,7 @@ func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 	for _, dnsHostname := range dnsHostnames {
 		dnsHostname = dns.EnsureDotSuffix(dnsHostname)
 		found := false
-		if cloud.ProviderID() != "vsphere" {
+		if cloud.ProviderID() != fi.CloudProviderVSphere {
 			dnsRecord := recordsMap["A::"+dnsHostname]
 			if dnsRecord != nil {
 				rrdatas := dnsRecord.Rrdatas()

--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -150,18 +150,22 @@ func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 		return fmt.Errorf("error getting DNS resource records for %q", zone.Name())
 	}
 
-	// TODO: We should change the filter to be a suffix match instead
-	//records, err := rrs.List("", "")
-	records, err := rrs.List()
-	if err != nil {
-		return fmt.Errorf("error listing DNS resource records for %q: %v", zone.Name(), err)
-	}
-
 	recordsMap := make(map[string]dnsprovider.ResourceRecordSet)
-	for _, record := range records {
-		name := dns.EnsureDotSuffix(record.Name())
-		key := string(record.Type()) + "::" + name
-		recordsMap[key] = record
+	// vSphere provider uses CoreDNS, which doesn't have rrs.List() function supported.
+	// Thus we use rrs.Get() to check every dnsHostname instead
+	if cloud.ProviderID() != "vsphere" {
+		// TODO: We should change the filter to be a suffix match instead
+		//records, err := rrs.List("", "")
+		records, err := rrs.List()
+		if err != nil {
+			return fmt.Errorf("error listing DNS resource records for %q: %v", zone.Name(), err)
+		}
+
+		for _, record := range records {
+			name := dns.EnsureDotSuffix(record.Name())
+			key := string(record.Type()) + "::" + name
+			recordsMap[key] = record
+		}
 	}
 
 	changeset := rrs.StartChangeset()
@@ -170,17 +174,39 @@ func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 
 	for _, dnsHostname := range dnsHostnames {
 		dnsHostname = dns.EnsureDotSuffix(dnsHostname)
-		dnsRecord := recordsMap["A::"+dnsHostname]
 		found := false
-		if dnsRecord != nil {
-			rrdatas := dnsRecord.Rrdatas()
-			if len(rrdatas) > 0 {
-				glog.V(4).Infof("Found DNS record %s => %s; won't create", dnsHostname, rrdatas)
-				found = true
-			} else {
-				// This is probably an alias target; leave it alone...
-				glog.V(4).Infof("Found DNS record %s, but no records", dnsHostname)
-				found = true
+		if cloud.ProviderID() != "vsphere" {
+			dnsRecord := recordsMap["A::"+dnsHostname]
+			if dnsRecord != nil {
+				rrdatas := dnsRecord.Rrdatas()
+				if len(rrdatas) > 0 {
+					glog.V(4).Infof("Found DNS record %s => %s; won't create", dnsHostname, rrdatas)
+					found = true
+				} else {
+					// This is probably an alias target; leave it alone...
+					glog.V(4).Infof("Found DNS record %s, but no records", dnsHostname)
+					found = true
+				}
+			}
+		} else {
+			dnsRecord, err := rrs.Get(dnsHostname)
+			if err != nil {
+				return fmt.Errorf("Failed to get DNS record %s with error: %v", dnsHostname, err)
+			}
+			if dnsRecord != nil {
+				if dnsRecord.Type() != "A" {
+					glog.V(4).Infof("Found DNS record %s with type %s, continue to create A type", dnsHostname, dnsRecord.Type())
+				} else {
+					rrdatas := dnsRecord.Rrdatas()
+					if len(rrdatas) > 0 {
+						glog.V(4).Infof("Found DNS record %s => %s; won't create", dnsHostname, rrdatas)
+						found = true
+					} else {
+						// This is probably an alias target; leave it alone...
+						glog.V(4).Infof("Found DNS record %s, but no records", dnsHostname)
+						found = true
+					}
+				}
 			}
 		}
 

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -51,6 +51,7 @@ type VSphereCloud struct {
 const (
 	snapshotName string = "LinkCloneSnapshotPoint"
 	snapshotDesc string = "Snapshot created by kops"
+	privateDNS   string = "coredns"
 )
 
 var _ fi.Cloud = &VSphereCloud{}
@@ -99,7 +100,7 @@ func (c *VSphereCloud) DNS() (dnsprovider.Interface, error) {
 
 	var provider dnsprovider.Interface
 	var err error
-	if dns_provider == "coredns" {
+	if dns_provider == privateDNS {
 		var lines []string
 		lines = append(lines, "etcd-endpoints = "+c.CoreDNSServer)
 		lines = append(lines, "zones = "+c.DNSZone)

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vsphere
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/golang/glog"
@@ -30,17 +31,21 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	k8sroute53 "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
+	k8scoredns "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/coredns"
 	"net/url"
 	"os"
+	"strings"
 )
 
 type VSphereCloud struct {
-	Server     string
-	Datacenter string
-	Cluster    string
-	Username   string
-	Password   string
-	Client     *govmomi.Client
+	Server        string
+	Datacenter    string
+	Cluster       string
+	Username      string
+	Password      string
+	Client        *govmomi.Client
+	CoreDNSServer string
+	DNSZone       string
 }
 
 const (
@@ -60,6 +65,8 @@ func NewVSphereCloud(spec *kops.ClusterSpec) (*VSphereCloud, error) {
 	cluster := *spec.CloudConfig.VSphereResourcePool
 	glog.V(2).Infof("Creating vSphere Cloud with server(%s), datacenter(%s), cluster(%s)", server, datacenter, cluster)
 
+	dns_server := *spec.CloudConfig.VSphereCoreDNSServer
+	dns_zone := spec.DNSZone
 	username := os.Getenv("VSPHERE_USERNAME")
 	password := os.Getenv("VSPHERE_PASSWORD")
 	if username == "" || password == "" {
@@ -81,17 +88,34 @@ func NewVSphereCloud(spec *kops.ClusterSpec) (*VSphereCloud, error) {
 	}
 	// Add retry functionality
 	c.RoundTripper = vim25.Retry(c.RoundTripper, vim25.TemporaryNetworkError(5))
-	vsphereCloud := &VSphereCloud{Server: server, Datacenter: datacenter, Cluster: cluster, Username: username, Password: password, Client: c}
+	vsphereCloud := &VSphereCloud{Server: server, Datacenter: datacenter, Cluster: cluster, Username: username, Password: password, Client: c, CoreDNSServer: dns_server, DNSZone: dns_zone}
 	glog.V(2).Infof("Created vSphere Cloud successfully: %+v", vsphereCloud)
 	return vsphereCloud, nil
 }
 
 func (c *VSphereCloud) DNS() (dnsprovider.Interface, error) {
-	glog.Warning("DNS() not implemented on VSphere")
-	provider, err := dnsprovider.GetDnsProvider(k8sroute53.ProviderName, nil)
-	if err != nil {
-		return nil, fmt.Errorf("Error building (k8s) DNS provider: %v", err)
+	// TODO: this is a temporary flag to toggle between CoreDNS and Route53, before CoreDNS is stable
+	dns_provider := os.Getenv("VSPHERE_DNS")
+
+	var provider dnsprovider.Interface
+	var err error
+	if dns_provider == "coredns" {
+		var lines []string
+		lines = append(lines, "etcd-endpoints = "+c.CoreDNSServer)
+		lines = append(lines, "zones = "+c.DNSZone)
+		config := "[global]\n" + strings.Join(lines, "\n") + "\n"
+		file := bytes.NewReader([]byte(config))
+		provider, err = dnsprovider.GetDnsProvider(k8scoredns.ProviderName, file)
+		if err != nil {
+			return nil, fmt.Errorf("Error building (k8s) DNS provider: %v", err)
+		}
+	} else {
+		provider, err = dnsprovider.GetDnsProvider(k8sroute53.ProviderName, nil)
+		if err != nil {
+			return nil, fmt.Errorf("Error building (k8s) DNS provider: %v", err)
+		}
 	}
+
 	return provider, nil
 
 }


### PR DESCRIPTION
Follow ocs/development/vsphere-dev.md for usage.
Set "export VSPHERE_DNS=coredns" to use CoreDNS. Otherwise Route53 is the default DNS service.
Add "--dns=private --vsphere-coredns-server=http://[DNS server's IP]:2379" into the "kops create cluster" command line.