### PR TITLE
Fixed cdrom to be connected during startup

### DIFF
--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -282,6 +282,7 @@ func (c *VSphereCloud) UploadAndAttachISO(vm *string, isoFile string) error {
 
 	// passing empty cd-rom name so that the first one gets returned
 	cdrom, err := devices.FindCdrom("")
+	cdrom.Connectable.StartConnected = true
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Tested that the cdrom is always connected during first poweron.