### PR TITLE
Add CoreDNS support into DNS controller addon image.

### DIFF
--- a/docs/development/vsphere-dev.md
+++ b/docs/development/vsphere-dev.md
@@ -10,7 +10,7 @@ Here is a [list of requirements and tasks](https://docs.google.com/document/d/10
 
 ## Setting up DNS
 Since vSphere doesn't have built-in DNS service, we use CoreDNS to support the DNS requirement in vSphere provider. This requires the users to setup a CoreDNS server before creating a kubernetes cluster. Please follow the following instructions to setup.
-Before the support of CoreDNS becomes stable, use env parameter "VSPHERE_DNS=coredns" to enable using CoreDNS. Or else AWS Route53 will be the default DNS service. To use Route53, follow instructions on: https://github.com/vmware/kops/blob/vsphere-develop/docs/aws.md
+**Before the support of CoreDNS becomes stable, use env parameter "VSPHERE_DNS=coredns"** to enable using CoreDNS. Or else AWS Route53 will be the default DNS service. To use Route53, follow instructions on: https://github.com/vmware/kops/blob/vsphere-develop/docs/aws.md
 
 For now we hardcoded DNS zone to skydns.local. So your cluster name should have suffix skydns.local, for example: "mycluster.skydns.local"
 
@@ -55,6 +55,17 @@ ns1.ns.dns.skydns.local. 160	IN	A	192.168.0.1
 
 ### Add DNS server information when create cluster
 Add ```--dns=private --vsphere-coredns-server=http://[DNS server's IP]:2379``` into the ```kops create cluster``` command line.
+
+### Use CoreDNS supported DNS Controller
+Information about DNS Controller can be found [here](https://github.com/kubernetes/kops/blob/master/dns-controller/README.md)
+Currently the DNS Controller is an add-on container and the image is from kope/dns-controller.
+Before the vSphere support is officially merged into upstream, we need to set up CoreDNS supported DNS controller manually.
+```bash
+DOCKER_REGISTRY=[your docker hub repo] make dns-controller-push
+export VSPHERE_DNSCONTROLLER_IMAGE=[your docker hub repo]
+make
+kops create cluster ...
+```
 
 ## Hacks
 

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/v1.5.2.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/v1.5.2.yaml.template
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       containers:
       - name: dns-controller
-        image: kope/dns-controller:1.5.2
+        image: {{ DnsControllerImage }}:1.5.2
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"os"
 	"strings"
 	"text/template"
 )
@@ -98,6 +99,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap) {
 	// TODO: Only for GCE?
 	dest["EncodeGCELabel"] = gce.EncodeGCELabel
 
+	dest["DnsControllerImage"] = tf.DnsControllerImage
 }
 
 // SharedVPC is a simple helper function which makes the templates for a shared VPC clearer
@@ -140,6 +142,7 @@ func (tf *TemplateFunctions) DnsControllerArgv() ([]string, error) {
 		argv = append(argv, "--dns=google-clouddns")
 	case fi.CloudProviderVSphere:
 		argv = append(argv, "--dns=coredns")
+		argv = append(argv, "--dns-server="+*tf.cluster.Spec.CloudConfig.VSphereCoreDNSServer)
 
 	default:
 		return nil, fmt.Errorf("unhandled cloudprovider %q", tf.cluster.Spec.CloudProvider)
@@ -162,4 +165,18 @@ func (tf *TemplateFunctions) DnsControllerArgv() ([]string, error) {
 	argv = append(argv, "-v=2")
 
 	return argv, nil
+}
+
+// TODO: this is a work-around before vSphere support is getting merged into upstream kops.
+// To use CoreDNS supported DNS Controller:
+// 1. DOCKER_REGISTRY=[your docker hub repo] make dns-controller-push
+// 2. export VSPHERE_DNSCONTROLLER_IMAGE=[your docker hub repo]
+// 3. make kops and create/apply cluster
+func (tf *TemplateFunctions) DnsControllerImage() (string, error) {
+	image := os.Getenv("VSPHERE_DNSCONTROLLER_IMAGE")
+	if fi.CloudProviderID(tf.cluster.Spec.CloudProvider) != fi.CloudProviderVSphere || image == "" {
+		return "kope/dns-controller", nil
+	} else {
+		return image, nil
+	}
 }


### PR DESCRIPTION
Currently a DNS controller addon will be started on each node to help update DNS record of nodes/pods/services.
This addon's image repo is by default kopes/dns-controller.
CoreDNS need a different initialization inside the dns-controller, which requires update of dns-controller code.
However before the support of vSphere/CoreDNS is upstream, we need to use CoreDNS supported dns-controller image from other repo.
This can be set by env VSPHERE_DNSCONTROLLER_IMAGE for now.
Please refer docs/development/vsphere-dev.md for detailed instructions.