### PR TITLE
Added code to enable nodeup and protokube building and execution for vSphere VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ version-dist: nodeup-dist kops-dist protokube-export utils-dist
 	cp .build/dist/linux/amd64/utils.tar.gz.sha1 .build/upload/kops/${VERSION}/linux/amd64/utils.tar.gz.sha1
 
 vsphere-setup:
-	hack/vsphere/vsphere_env.sh
+	hack/vsphere/vsphere_env.sh --set
 
 vsphere-version-dist: vsphere-setup nodeup-dist protokube-export
 	rm -rf .build/upload

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,27 @@ version-dist: nodeup-dist kops-dist protokube-export utils-dist
 	cp .build/dist/linux/amd64/utils.tar.gz .build/upload/kops/${VERSION}/linux/amd64/utils.tar.gz
 	cp .build/dist/linux/amd64/utils.tar.gz.sha1 .build/upload/kops/${VERSION}/linux/amd64/utils.tar.gz.sha1
 
+vsphere-setup:
+	hack/vsphere/vsphere_env.sh
+
+vsphere-version-dist: vsphere-setup nodeup-dist protokube-export
+	rm -rf .build/upload
+	mkdir -p .build/upload/kops/${VERSION}/linux/amd64/
+	mkdir -p .build/upload/kops/${VERSION}/darwin/amd64/
+	mkdir -p .build/upload/kops/${VERSION}/images/
+	mkdir -p .build/upload/utils/${VERSION}/linux/amd64/
+	cp .build/dist/nodeup .build/upload/kops/${VERSION}/linux/amd64/nodeup
+	cp .build/dist/nodeup.sha1 .build/upload/kops/${VERSION}/linux/amd64/nodeup.sha1
+	cp .build/dist/images/protokube.tar.gz .build/upload/kops/${VERSION}/images/protokube.tar.gz
+	cp .build/dist/images/protokube.tar.gz.sha1 .build/upload/kops/${VERSION}/images/protokube.tar.gz.sha1
+	scp -r .build/dist/nodeup* ${TARGET}:${TARGET_PATH}/nodeup
+	scp -r .build/dist/images/protokube.tar.gz* ${TARGET}:${TARGET_PATH}/protokube/
+	make kops-dist
+	cp .build/dist/linux/amd64/kops .build/upload/kops/${VERSION}/linux/amd64/kops
+	cp .build/dist/linux/amd64/kops.sha1 .build/upload/kops/${VERSION}/linux/amd64/kops.sha1
+	cp .build/dist/darwin/amd64/kops .build/upload/kops/${VERSION}/darwin/amd64/kops
+	cp .build/dist/darwin/amd64/kops.sha1 .build/upload/kops/${VERSION}/darwin/amd64/kops.sha1
+
 upload: kops version-dist
 	aws s3 sync --acl public-read .build/upload/ ${S3_BUCKET}
 

--- a/hack/vsphere/vsphere_env.sh
+++ b/hack/vsphere/vsphere_env.sh
@@ -1,0 +1,39 @@
+# If set, coredns will be used for vsphere cloud provider.
+export VSPHERE_DNS=coredns
+
+# If set, this dns controller image will be used.
+# Leave this value unmodified if you are not building a new dns-controller image.
+export VSPHERE_DNSCONTROLLER_IMAGE=luomiao/dns-controller
+
+# S3 bucket that kops should use.
+export KOPS_STATE_STORE=s3://your-obj-store
+
+# AWS credentials
+export AWS_REGION=us-west-2
+export AWS_ACCESS_KEY_ID=something
+export AWS_SECRET_ACCESS_KEY=something
+
+# vSphere credentials
+export VSPHERE_USERNAME=administrator@vsphere.local
+export VSPHERE_PASSWORD=Admin!23
+
+# Set TARGET and TARGET_PATH to values where you want nodeup and protokube binaries to get copied. 
+# This should be same location as set for NODEUP_URL and PROTOKUBE_IMAGE. 
+export TARGET=jdoe@pa-dbc1131.eng.vmware.com
+export TARGET_PATH=/dbc/pa-dbc1131/jdoe/misc/kops/
+
+export NODEUP_URL=http://pa-dbc1131.eng.vmware.com/jdoe/misc/kops/nodeup/nodeup
+export PROTOKUBE_IMAGE=http://pa-dbc1131.eng.vmware.com/jdoe/misc/kops/protokube/protokube.tar.gz
+
+echo "VSPHERE_DNS=${VSPHERE_DNS}"
+echo "VSPHERE_DNSCONTROLLER_IMAGE=${VSPHERE_DNSCONTROLLER_IMAGE}"
+echo "KOPS_STATE_STORE=${KOPS_STATE_STORE}"
+echo "AWS_REGION=${AWS_REGION}"
+echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+echo "VSPHERE_USERNAME=${VSPHERE_USERNAME}"
+echo "VSPHERE_PASSWORD=${VSPHERE_PASSWORD}"
+echo "NODEUP_URL=${NODEUP_URL}"
+echo "PROTOKUBE_IMAGE=${PROTOKUBE_IMAGE}"
+echo "TARGET=${TARGET}"
+echo "TARGET_PATH=${TARGET_PATH}"

--- a/hack/vsphere/vsphere_env.sh
+++ b/hack/vsphere/vsphere_env.sh
@@ -1,39 +1,98 @@
-# If set, coredns will be used for vsphere cloud provider.
-export VSPHERE_DNS=coredns
+#!/usr/bin/env bash
 
-# If set, this dns controller image will be used.
-# Leave this value unmodified if you are not building a new dns-controller image.
-export VSPHERE_DNSCONTROLLER_IMAGE=luomiao/dns-controller
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# S3 bucket that kops should use.
-export KOPS_STATE_STORE=s3://your-obj-store
+if [ $# -ne 1 ]; then
+    echo Usage: vsphere_env [options]
+    echo Options:
+    echo -e "\t -s, --set   \t Set environment variables."
+    echo -e "\t -u, --unset \t Unset environment variables."
+    exit 1
+fi
 
-# AWS credentials
-export AWS_REGION=us-west-2
-export AWS_ACCESS_KEY_ID=something
-export AWS_SECRET_ACCESS_KEY=something
+option="$1"
+flag=0
 
-# vSphere credentials
-export VSPHERE_USERNAME=administrator@vsphere.local
-export VSPHERE_PASSWORD=Admin!23
+case $option in
+    -s | --set)
+    # If set, coredns will be used for vsphere cloud provider.
+    export VSPHERE_DNS=coredns
 
-# Set TARGET and TARGET_PATH to values where you want nodeup and protokube binaries to get copied. 
-# This should be same location as set for NODEUP_URL and PROTOKUBE_IMAGE. 
-export TARGET=jdoe@pa-dbc1131.eng.vmware.com
-export TARGET_PATH=/dbc/pa-dbc1131/jdoe/misc/kops/
+    # If set, this dns controller image will be used.
+    # Leave this value unmodified if you are not building a new dns-controller image.
+    export VSPHERE_DNSCONTROLLER_IMAGE=luomiao/dns-controller
 
-export NODEUP_URL=http://pa-dbc1131.eng.vmware.com/jdoe/misc/kops/nodeup/nodeup
-export PROTOKUBE_IMAGE=http://pa-dbc1131.eng.vmware.com/jdoe/misc/kops/protokube/protokube.tar.gz
+    # S3 bucket that kops should use.
+    export KOPS_STATE_STORE=s3://your-obj-store
 
-echo "VSPHERE_DNS=${VSPHERE_DNS}"
-echo "VSPHERE_DNSCONTROLLER_IMAGE=${VSPHERE_DNSCONTROLLER_IMAGE}"
-echo "KOPS_STATE_STORE=${KOPS_STATE_STORE}"
-echo "AWS_REGION=${AWS_REGION}"
-echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
-echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
-echo "VSPHERE_USERNAME=${VSPHERE_USERNAME}"
-echo "VSPHERE_PASSWORD=${VSPHERE_PASSWORD}"
-echo "NODEUP_URL=${NODEUP_URL}"
-echo "PROTOKUBE_IMAGE=${PROTOKUBE_IMAGE}"
-echo "TARGET=${TARGET}"
-echo "TARGET_PATH=${TARGET_PATH}"
+    # AWS credentials
+    export AWS_REGION=us-west-2
+    export AWS_ACCESS_KEY_ID=something
+    export AWS_SECRET_ACCESS_KEY=something
+
+    # vSphere credentials
+    export VSPHERE_USERNAME=administrator@vsphere.local
+    export VSPHERE_PASSWORD=Admin!23
+
+    # Set TARGET and TARGET_PATH to values where you want nodeup and protokube binaries to get copied.
+    # This should be same location as set for NODEUP_URL and PROTOKUBE_IMAGE.
+    export TARGET=jdoe@pa-dbc1131.eng.vmware.com
+    export TARGET_PATH=/dbc/pa-dbc1131/jdoe/misc/kops/
+
+    export NODEUP_URL=http://pa-dbc1131.eng.vmware.com/jdoe/misc/kops/nodeup/nodeup
+    export PROTOKUBE_IMAGE=http://pa-dbc1131.eng.vmware.com/jdoe/misc/kops/protokube/protokube.tar.gz
+
+    flag=1
+    ;;
+    -u | --unset)
+    export VSPHERE_DNS=
+    export VSPHERE_DNSCONTROLLER_IMAGE=
+    export KOPS_STATE_STORE=
+    export AWS_REGION=
+    export AWS_ACCESS_KEY_ID=
+    export AWS_SECRET_ACCESS_KEY=
+    export VSPHERE_USERNAME=
+    export VSPHERE_PASSWORD=
+    export TARGET=
+    export TARGET_PATH=
+    export NODEUP_URL=
+    export PROTOKUBE_IMAGE=
+
+    flag=1
+    ;;
+    --default)
+    echo Usage: vsphere_env [options]
+    echo Options:
+    echo -e "\t -s, --set   \t Set environment variables."
+    echo -e "\t -u, --unset \t Unset environment variables."
+    exit 1
+    ;;
+    *)
+esac
+
+if [[ $flag -ne 0 ]]; then
+    echo "VSPHERE_DNS=${VSPHERE_DNS}"
+    echo "VSPHERE_DNSCONTROLLER_IMAGE=${VSPHERE_DNSCONTROLLER_IMAGE}"
+    echo "KOPS_STATE_STORE=${KOPS_STATE_STORE}"
+    echo "AWS_REGION=${AWS_REGION}"
+    echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+    echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+    echo "VSPHERE_USERNAME=${VSPHERE_USERNAME}"
+    echo "VSPHERE_PASSWORD=${VSPHERE_PASSWORD}"
+    echo "NODEUP_URL=${NODEUP_URL}"
+    echo "PROTOKUBE_IMAGE=${PROTOKUBE_IMAGE}"
+    echo "TARGET=${TARGET}"
+    echo "TARGET_PATH=${TARGET_PATH}"
+fi

--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -17,6 +17,7 @@ limitations under the License.
 package bootstrap
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/golang/glog"
 	"k8s.io/kops/nodeup/pkg/distros"
@@ -26,10 +27,9 @@ import (
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"os"
 	"strings"
 	"time"
-	"os"
-	"bytes"
 )
 
 type Installation struct {
@@ -111,7 +111,7 @@ func (i *Installation) buildSystemdJob() *nodetasks.Service {
 	manifest.Set("Unit", "Documentation", "https://github.com/kubernetes/kops")
 
 	// TODO temporary code, till vsphere cloud provider gets its own VFS implementation.
-	if os.Getenv("AWS_REGION") != "" ||  os.Getenv("AWS_ACCESS_KEY_ID") != "" || os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
+	if os.Getenv("AWS_REGION") != "" || os.Getenv("AWS_ACCESS_KEY_ID") != "" || os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
 		var buffer bytes.Buffer
 		buffer.WriteString("\"AWS_REGION=")
 		buffer.WriteString(os.Getenv("AWS_REGION"))

--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 	"strings"
 	"time"
+	"os"
+	"bytes"
 )
 
 type Installation struct {
@@ -107,6 +109,22 @@ func (i *Installation) buildSystemdJob() *nodetasks.Service {
 	manifest := &systemd.Manifest{}
 	manifest.Set("Unit", "Description", "Run kops bootstrap (nodeup)")
 	manifest.Set("Unit", "Documentation", "https://github.com/kubernetes/kops")
+
+	// TODO temporary code, till vsphere cloud provider gets its own VFS implementation.
+	if os.Getenv("AWS_REGION") != "" ||  os.Getenv("AWS_ACCESS_KEY_ID") != "" || os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
+		var buffer bytes.Buffer
+		buffer.WriteString("\"AWS_REGION=")
+		buffer.WriteString(os.Getenv("AWS_REGION"))
+		buffer.WriteString("\" ")
+		buffer.WriteString("\"AWS_ACCESS_KEY_ID=")
+		buffer.WriteString(os.Getenv("AWS_ACCESS_KEY_ID"))
+		buffer.WriteString("\" ")
+		buffer.WriteString("\"AWS_SECRET_ACCESS_KEY=")
+		buffer.WriteString(os.Getenv("AWS_SECRET_ACCESS_KEY"))
+		buffer.WriteString("\" ")
+
+		manifest.Set("Service", "Environment", buffer.String())
+	}
 
 	manifest.Set("Service", "ExecStart", command)
 	manifest.Set("Service", "Type", "oneshot")

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -22,12 +22,15 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup"
 	"text/template"
+	"os"
 )
 
 // BootstrapScript creates the bootstrap script
 type BootstrapScript struct {
 	NodeUpSource     string
 	NodeUpSourceHash string
+	// TODO temporary field to enable workflow for vSphere cloud provider.
+	AddAwsEnvironmentVariables bool
 
 	NodeUpConfigBuilder func(ig *kops.InstanceGroup) (*nodeup.NodeUpConfig, error)
 }
@@ -57,6 +60,25 @@ func (b *BootstrapScript) ResourceNodeUp(ig *kops.InstanceGroup) (*fi.ResourceHo
 			}
 
 			return string(data), nil
+		},
+		// TODO temporary code, till vsphere cloud provider gets its own VFS implementation.
+		"Env1": func() string {
+			if b.AddAwsEnvironmentVariables && os.Getenv("AWS_REGION") != "" {
+				return "export AWS_REGION=" + os.Getenv("AWS_REGION")
+			}
+			return ""
+		},
+		"Env2": func() string {
+			if b.AddAwsEnvironmentVariables && os.Getenv("AWS_ACCESS_KEY_ID") != "" {
+				return "export AWS_ACCESS_KEY_ID=" + os.Getenv("AWS_ACCESS_KEY_ID")
+			}
+			return ""
+		},
+		"Env3": func() string {
+			if b.AddAwsEnvironmentVariables && os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
+				return "export AWS_SECRET_ACCESS_KEY=" + os.Getenv("AWS_SECRET_ACCESS_KEY")
+			}
+			return ""
 		},
 	}
 

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -21,8 +21,8 @@ import (
 	"k8s.io/kops/pkg/model/resources"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup"
-	"text/template"
 	"os"
+	"text/template"
 )
 
 // BootstrapScript creates the bootstrap script
@@ -82,7 +82,12 @@ func (b *BootstrapScript) ResourceNodeUp(ig *kops.InstanceGroup) (*fi.ResourceHo
 		},
 	}
 
-	templateResource, err := NewTemplateResource("nodeup", resources.AWSNodeUpTemplate, functions, nil)
+	nodeupTemplate := resources.AWSNodeUpTemplate
+	if b.AddAwsEnvironmentVariables {
+		nodeupTemplate = resources.VsphereNodeUpTemplate
+	}
+
+	templateResource, err := NewTemplateResource("nodeup", nodeupTemplate, functions, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -38,6 +38,10 @@ set -o pipefail
 NODEUP_URL={{ NodeUpSource }}
 NODEUP_HASH={{ NodeUpSourceHash }}
 
+{{ Env1 }}
+{{ Env2 }}
+{{ Env3 }}
+
 function ensure-install-dir() {
   INSTALL_DIR="/var/cache/kubernetes-install"
   mkdir -p ${INSTALL_DIR}

--- a/pkg/model/resources/vsphere_nodeup.go
+++ b/pkg/model/resources/vsphere_nodeup.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ limitations under the License.
 
 package resources
 
-var AWSNodeUpTemplate = `#!/bin/bash
+var VsphereNodeUpTemplate = `#!/bin/bash
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,10 @@ set -o pipefail
 
 NODEUP_URL={{ NodeUpSource }}
 NODEUP_HASH={{ NodeUpSourceHash }}
+
+{{ Env1 }}
+{{ Env2 }}
+{{ Env3 }}
 
 function ensure-install-dir() {
   INSTALL_DIR="/var/cache/kubernetes-install"

--- a/pkg/model/vspheremodel/autoscalinggroup.go
+++ b/pkg/model/vspheremodel/autoscalinggroup.go
@@ -31,8 +31,6 @@ type AutoscalingGroupModelBuilder struct {
 
 var _ fi.ModelBuilder = &AutoscalingGroupModelBuilder{}
 
-const defaultVmTemplateName = "Ubuntu_16_10"
-
 func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	// Note that we are creating a VM per instance group. Instance group represents a group of VMs.
 	// The following logic should considerably change once we add support for multiple master/worker nodes,
@@ -41,7 +39,7 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		name := b.AutoscalingGroupName(ig)
 		createVmTask := &vspheretasks.VirtualMachine{
 			Name:           &name,
-			VMTemplateName: fi.String(defaultVmTemplateName),
+			VMTemplateName: fi.String(ig.Spec.Image),
 		}
 
 		c.AddTask(createVmTask)
@@ -53,6 +51,8 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			IG:              ig,
 			BootstrapScript: b.BootstrapScript,
 		}
+		attachISOTask.BootstrapScript.AddAwsEnvironmentVariables = true
+
 		c.AddTask(attachISOTask)
 
 		powerOnTaskName := "PowerON-" + name

--- a/upup/models/nodeup/_protokube/services/protokube.service.template
+++ b/upup/models/nodeup/_protokube/services/protokube.service.template
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 EnvironmentFile=/etc/sysconfig/protokube
 ExecStartPre={{ ProtokubeImagePullCommand }}
-ExecStart=/usr/bin/docker run -v /:/rootfs/ -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --net=host --privileged {{ ProtokubeImageName }} /usr/bin/protokube "$DAEMON_ARGS"
+ExecStart=/usr/bin/docker run -v /:/rootfs/ -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --net=host --privileged {{ ProtokubeEnvironmentVariables }} {{ ProtokubeImageName }} /usr/bin/protokube "$DAEMON_ARGS"
 Restart=always
 RestartSec=2s
 StartLimitInterval=0

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -550,9 +550,9 @@ func (c *ApplyClusterCmd) Run() error {
 	}
 
 	bootstrapScriptBuilder := &model.BootstrapScript{
-		NodeUpConfigBuilder: renderNodeUpConfig,
-		NodeUpSourceHash:    "",
-		NodeUpSource:        c.NodeUpSource,
+		NodeUpConfigBuilder:        renderNodeUpConfig,
+		NodeUpSourceHash:           "",
+		NodeUpSource:               c.NodeUpSource,
 		AddAwsEnvironmentVariables: false,
 	}
 	switch fi.CloudProviderID(cluster.Spec.CloudProvider) {

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -553,6 +553,7 @@ func (c *ApplyClusterCmd) Run() error {
 		NodeUpConfigBuilder: renderNodeUpConfig,
 		NodeUpSourceHash:    "",
 		NodeUpSource:        c.NodeUpSource,
+		AddAwsEnvironmentVariables: false,
 	}
 	switch fi.CloudProviderID(cluster.Spec.CloudProvider) {
 	case fi.CloudProviderAWS:

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -42,7 +42,7 @@ const (
 	defaultMasterMachineTypeAWS     = "m3.medium"
 	defaultMasterMachineTypeVSphere = "vsphere_master"
 
-	defaultVSphereNodeImage         = "ubuntu_16_04"
+	defaultVSphereNodeImage = "ubuntu_16_04"
 )
 
 var masterMachineTypeExceptions = map[string]string{

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -41,6 +41,8 @@ const (
 	defaultMasterMachineTypeGCE     = "n1-standard-1"
 	defaultMasterMachineTypeAWS     = "m3.medium"
 	defaultMasterMachineTypeVSphere = "vsphere_master"
+
+	defaultVSphereNodeImage         = "ubuntu_16_04"
 )
 
 var masterMachineTypeExceptions = map[string]string{
@@ -228,8 +230,9 @@ func defaultImage(cluster *api.Cluster, channel *api.Channel) string {
 				return image.Name
 			}
 		}
+	} else if fi.CloudProviderID(cluster.Spec.CloudProvider) == fi.CloudProviderVSphere {
+		return defaultVSphereNodeImage
 	}
-
 	glog.Infof("Cannot set default Image for CloudProvider=%q", cluster.Spec.CloudProvider)
 	return ""
 }

--- a/upup/pkg/fi/nodeup/template_functions.go
+++ b/upup/pkg/fi/nodeup/template_functions.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"text/template"
 
+	"bytes"
 	"github.com/golang/glog"
 	"k8s.io/kops"
 	api "k8s.io/kops/pkg/apis/kops"
@@ -31,7 +32,6 @@ import (
 	"k8s.io/kops/upup/pkg/fi/secrets"
 	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kubernetes/pkg/util/sets"
-	"bytes"
 	"os"
 )
 


### PR DESCRIPTION
Changes:
1. Added logic to pass necessary AWS credentials to nodeup, via cloud-init script.
2. Added logic to pass necessary AWS credentials to protokube via nodeup code.
3. Added make target for ease of kops, nodeup and protokube building, and also added necessary script to make use of these built binaries and images while running kops.
4. Added support to accept --image flag during cluster creation for vSphere cloud provider. 

Testing:
1. Deployed kops using following command and made sure that
1.1 --image flag is getting used properly.
1.2 Verified that script.sh generated for master node contains AWS environment variable set.
1.3 Verified that kops-configuration.service file and protokube.service files have AWS credentials set at appropriate locations.
2. Successfully brought up master node after manually updating /etc/resolve.conf with codedns server IP.

