### PR TITLE
Removed hardcode from protokube logic. Fixes #15.

### DIFF
--- a/docs/development/vsphere-dev.md
+++ b/docs/development/vsphere-dev.md
@@ -93,7 +93,7 @@ Please note that dns-controller has also been modified to support vSphere. You c
 Execute following command to launch cluster.
 
 ```bash
-.build/dist/darwin/amd64/kops create cluster kubernetes.skydns.local  --cloud=vsphere --zones=${AWS_REGION}a --dns-zone=skydns.local --networking=flannel
+.build/dist/darwin/amd64/kops create cluster kubernetes.skydns.local  --cloud=vsphere --zones=vmware-zone --dns-zone=skydns.local --networking=flannel
  --vsphere-server=10.160.97.44 --vsphere-datacenter=VSAN-DC --vsphere-resource-pool=VSAN-Cluster --vsphere-datastore=vsanDatastore --dns private --vsphere-coredns-server=http://10.192.217.24:2379 --image="ubuntu_16_04" 
 ```
 
@@ -102,7 +102,7 @@ Use .build/dist/linux/amd64/kops if working on a linux machine, instead of mac.
 **Notes**
 
 1. ```clustername``` should end with **skydns.local**. Example: ```kubernetes.cluster.skydns.local```.
-2. ```zones``` should end with ```a```. Example: ```us-west-2a``` or as the above command sets ```--zones=${AWS_REGION}a```.
+2. For ```zones``` any string will do, for now. It's only getting used for the construction of names of various entities. But it's a mandatory argument.
 3. Make sure following parameters have these values,
     * ```--dns-zone=skydns.local```
     * ```--networking=flannel```

--- a/pkg/model/vspheremodel/autoscalinggroup.go
+++ b/pkg/model/vspheremodel/autoscalinggroup.go
@@ -57,6 +57,7 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				VM:              createVmTask,
 				IG:              ig,
 				BootstrapScript: b.BootstrapScript,
+				EtcdClusters:    b.Cluster.Spec.EtcdClusters,
 			}
 			attachISOTask.BootstrapScript.AddAwsEnvironmentVariables = true
 

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_volume_metadata.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_volume_metadata.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+type VolumeMetadata struct {
+	// EtcdClusterName is the name of the etcd cluster (main, events etc)
+	EtcdClusterName string `json:"etcdClusterName,omitempty"`
+	// EtcdNodeName is the name of a node in etcd cluster for which this volume will be used
+	EtcdNodeName string `json:"etcdNodeName,omitempty"`
+	// EtcdMember stores the configurations for each member of the cluster
+	Members []EtcdMemberSpec `json:"etcdMembers,omitempty"`
+	// Volume id
+	VolumeId string `json:"volumeId,omitempty"`
+}
+
+type EtcdMemberSpec struct {
+	// Name is the name of the member within the etcd cluster
+	Name          string `json:"name,omitempty"`
+	InstanceGroup string `json:"instanceGroup,omitempty"`
+}
+
+func MarshalVolumeMetadata(v []VolumeMetadata) (string, error) {
+	metadata, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+
+	return string(metadata), nil
+}
+
+func UnmarshalVolumeMetadata(text string) ([]VolumeMetadata, error) {
+	var v []VolumeMetadata
+	err := json.Unmarshal([]byte(text), &v)
+	return v, err
+}
+
+func GetVolumeId(i int) string {
+	return "0" + strconv.Itoa(i)
+}
+
+/*
+ * GetMountPoint will return the mount point where the volume is expected to be mounted.
+ * This path would be /mnt/master-<volumeId>, eg: /mnt/master-01.
+ */
+func GetMountPoint(volumeId string) string {
+	return "/mnt/master-" + volumeId
+}

--- a/upup/pkg/fi/cloudup/vspheretasks/cloud_init.go
+++ b/upup/pkg/fi/cloudup/vspheretasks/cloud_init.go
@@ -34,6 +34,11 @@ $VM_UUID
     owner: root:root
     path: /root/vm_uuid
     permissions: "0644"
+  - content: |
+$VOLUME_SCRIPT
+    owner: root:root
+    path: /vol-metadata/metadata.json
+    permissions: "0644"
 
 runcmd:
   - bash /root/update_dns.sh 2>&1 > /var/log/update_dns.log


### PR DESCRIPTION
Changes:

Populating volume metadata based on actual zone name passed in 'kops cluster create' command.
Updated protokube code to use volume metadata and create volume and etcd cluster spec.
Testing:

Ran 'make ci'

Successfully deployed cluster with following command, please note the 'zone' argument-

kops create cluster --cloud=vsphere --name=v2c2.skydns.local --zones=vmw-zone --vsphere-server=10.160.236.59 --vsphere-datacenter=VSAN-DC --vsphere-resource-pool=VSAN-Cluster --vsphere-datastore=vsanDatastore --dns=private --vsphere-coredns-server=http://10.160.227.86:2379 --dns-zone=skydns.local --image=ubuntu_16_04 --node-count=2 --networking=flannel --yes

Checked protokube logs to make sure correct volume data is getting populated, along with etcd cluster information. Here is the log snippet-
I0411 18:18:00.874477       1 vsphere_volume.go:88] Found volumes: [{"ID":"01","LocalDevice":"/dev/sdb1","AttachedTo":"10.160.249.78","Mountpoint":"/mnt/master-01","Status":"attached","Info":{"Description":"main","EtcdClusters":[{"clusterKey":"main","nodeName":"e","nodeNames":["e"]}]}} {"ID":"02","LocalDevice":"/dev/sdc1","AttachedTo":"10.160.249.78","Mountpoint":"/mnt/master-02","Status":"attached","Info":{"Description":"events","EtcdClusters":[{"clusterKey":"events","nodeName":"e","nodeNames":["e"]}]}}]