### PR TITLE
Failing unsupported commands with proper message. Fixes #48.

### DIFF
--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -80,6 +80,12 @@ func RunCreateInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, 
 		return err
 	}
 
+	// Validate the usage of this command for the cloud provider.
+	err = util.ValidateUsage(util.CreateInstanceGroup, cluster.Spec.CloudProvider)
+	if err != nil {
+		return err
+	}
+
 	clientset, err := rootCommand.Clientset()
 	if err != nil {
 		return err

--- a/cmd/kops/delete_instancegroup.go
+++ b/cmd/kops/delete_instancegroup.go
@@ -109,6 +109,12 @@ func RunDeleteInstanceGroup(f *util.Factory, out io.Writer, options *DeleteInsta
 		return err
 	}
 
+	// Validate the usage of this command for the cloud provider.
+	err = util.ValidateUsage(util.DeleteInstanceGroup, cluster.Spec.CloudProvider)
+	if err != nil {
+		return err
+	}
+
 	clientset, err := f.Clientset()
 	if err != nil {
 		return err

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -71,6 +71,12 @@ func RunEditCluster(f *util.Factory, cmd *cobra.Command, args []string, out io.W
 		return err
 	}
 
+	// Validate the usage of this command for the cloud provider.
+	err = util.ValidateUsage(util.EditCluster, oldCluster.Spec.CloudProvider)
+	if err != nil {
+		return err
+	}
+
 	err = oldCluster.FillDefaults()
 	if err != nil {
 		return err

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -74,6 +74,12 @@ func RunEditInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, ou
 		return err
 	}
 
+	// Validate the usage of this command for the cloud provider.
+	err = util.ValidateUsage(util.EditInstanceGroup, cluster.Spec.CloudProvider)
+	if err != nil {
+		return err
+	}
+
 	channel, err := cloudup.ChannelForCluster(cluster)
 	if err != nil {
 		return err

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -90,6 +90,11 @@ func RunReplace(f *util.Factory, cmd *cobra.Command, out io.Writer, c *ReplaceOp
 				}
 
 			case *kopsapi.Cluster:
+				// Validate the usage of this command for the cloud provider.
+				err = util.ValidateUsage(util.ReplaceUsingFileName, v.Spec.CloudProvider)
+				if err != nil {
+					return err
+				}
 				_, err = clientset.Clusters().Update(v)
 				if err != nil {
 					return fmt.Errorf("error replacing cluster: %v", err)

--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -158,6 +158,12 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		return err
 	}
 
+	// Validate the usage of this command for the cloud provider.
+	err = util.ValidateUsage(util.RollingUpdate, cluster.Spec.CloudProvider)
+	if err != nil {
+		return err
+	}
+
 	contextName := cluster.ObjectMeta.Name
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),

--- a/cmd/kops/toolbox_convert_imported.go
+++ b/cmd/kops/toolbox_convert_imported.go
@@ -82,6 +82,12 @@ func RunToolboxConvertImported(f *util.Factory, out io.Writer, options *ToolboxC
 		return err
 	}
 
+	// Validate the usage of this command for the cloud provider.
+	err = util.ValidateUsage(util.ToolboxConvertImported, cluster.Spec.CloudProvider)
+	if err != nil {
+		return err
+	}
+
 	list, err := clientset.InstanceGroups(cluster.ObjectMeta.Name).List(metav1.ListOptions{})
 	if err != nil {
 		return err

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -121,6 +121,12 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 		return err
 	}
 
+	// Validate the usage of this command for the cloud provider.
+	err = util.ValidateUsage(util.UpdateCluster, cluster.Spec.CloudProvider)
+	if err != nil {
+		return err
+	}
+
 	keyStore, err := registry.KeyStore(cluster)
 	if err != nil {
 		return err

--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops"
+	cmdutil "k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/apis/kops/validation"
@@ -76,6 +77,12 @@ func (c *UpgradeClusterCmd) Run(args []string) error {
 	}
 
 	cluster, err := rootCommand.Cluster()
+	if err != nil {
+		return err
+	}
+
+	// Validate the usage of this command for the cloud provider.
+	err = cmdutil.ValidateUsage(cmdutil.UpgradeCluster, cluster.Spec.CloudProvider)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/util/validate_usage.go
+++ b/cmd/kops/util/validate_usage.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+// validate_usage houses the logic to validate usage of a kops command for a given cloud provider.
+
+import (
+	"fmt"
+	"k8s.io/kops/pkg/featureflag"
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+const (
+	CreateWithFileName     = "create -f"
+	CreateInstanceGroup    = "create ig"
+	DeleteInstanceGroup    = "delete ig"
+	DeleteWithFileName     = "delete -f"
+	EditCluster            = "edit cluster"
+	EditInstanceGroup      = "edit ig"
+	EditFederation         = "edit federation"
+	ImportCluster          = "import cluster"
+	ReplaceUsingFileName   = "replace -f"
+	RollingUpdate          = "rolling-update cluster"
+	ToolboxConvertImported = "toolbox convert-imported"
+	UpdateCluster          = "update cluster"
+	UpdateFederation       = "update federation"
+	UpgradeCluster         = "upgrade cluster"
+)
+
+var unsupportedCommandsForVSphere = map[string]bool{
+	CreateWithFileName:     true,
+	CreateInstanceGroup:    true,
+	DeleteInstanceGroup:    true,
+	DeleteWithFileName:     true,
+	EditCluster:            true,
+	EditInstanceGroup:      true,
+	EditFederation:         true,
+	ImportCluster:          true,
+	ReplaceUsingFileName:   true,
+	RollingUpdate:          true,
+	ToolboxConvertImported: true,
+	UpdateCluster:          true,
+	UpdateFederation:       true,
+	UpgradeCluster:         true,
+}
+
+// ValidateUsage checks if the given command is usable for the given cloud provider. In case it's not, error is returned, else nil.
+func ValidateUsage(command, cloudProvider string) error {
+
+	if fi.CloudProviderVSphere == fi.CloudProviderID(cloudProvider) {
+		if !featureflag.VSphereCloudProvider.Enabled() {
+			return fmt.Errorf("Feature flag VSphereCloudProvider is not set. Cloud vSphere will not be supported.")
+		}
+		if unsupportedCommandsForVSphere[command] {
+			return fmt.Errorf("Command %v is not yet supported for vsphere cloud provider.", command)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Commands followed by error message**

With feature flag set:

kops create ig --name=v1c1.skydns.local --role=Node --subnet=vmw-zone nodes2
Command create ig is not yet supported for vsphere cloud provider.

kops  delete instancegroup --name=v1c1.skydns.local  nodes.v1c1.skydns.local
Command delete ig is not yet supported for vsphere cloud provider.

kops  delete -f ~/Downloads/inbox/kops/s3-state/cluster3/vSphere/kops.nodeig.yaml  --name=v1c1.skydns.local --yes
Command delete ig is not yet supported for vsphere cloud provider.

kops edit cluster  --name=v1c1.skydns.local
Command edit cluster is not yet supported for vsphere cloud provider.

kops edit ig --name=v1c1.skydns.local nodes
Command edit ig is not yet supported for vsphere cloud provider.

kops  replace -f ~/Downloads/inbox/kops/s3-state/cluster3/vSphere/config.yaml  --name=v1c1.skydns.local
error: Command replace -f is not yet supported for vsphere cloud provider.

kops rolling-update cluster --name=v1c1.skydns.local
Command rolling-update cluster is not yet supported for vsphere cloud provider.

kops toolbox convert-imported  --name=v1c1.skydns.local
Command toolbox convert-imported is not yet supported for vsphere cloud provider.

kops update cluster --name=v1c1.skydns.local
Command update cluster is not yet supported for vsphere cloud provider.

kops upgrade cluster  --name=v1c1.skydns.local
Command upgrade cluster is not yet supported for vsphere cloud provider.

Without feature flag:

kops edit ig --name=v1c1.skydns.local nodes
Feature flag VSphereCloudProvider is not set. Cloud vSphere will not be supported.

This fix does not include following commands because no cloud provider is getting queried for these commands. So it's not possible to decide if a command is meant for vSphere. Additional parameters will have to be added for this. 

- replace -f for instance groups
- edit federation
- update federation
- import cluster