### PR TITLE
Removed usage validation from update cmd, unbloking create cmd.

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -121,12 +121,6 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 		return err
 	}
 
-	// Validate the usage of this command for the cloud provider.
-	err = util.ValidateUsage(util.UpdateCluster, cluster.Spec.CloudProvider)
-	if err != nil {
-		return err
-	}
-
 	keyStore, err := registry.KeyStore(cluster)
 	if err != nil {
 		return err


### PR DESCRIPTION
Removed usage validation from update command. This check was blocking create command, which internal uses update command, if --yes flag is specified.

This means that update command for existing cluster will continue to fail for vSphere, until this is fixed https://github.com/vmware/kops/issues/51